### PR TITLE
Add support for /* glsl */ comments

### DIFF
--- a/syntaxes/glsl-literal.json
+++ b/syntaxes/glsl-literal.json
@@ -3,7 +3,7 @@
   "injectionSelector": "L:source -comment -string",
   "patterns": [
     {
-      "begin": "(glsl|glslify|vert|frag)(`)|(`)\/\/(inline|glsl)",
+      "begin": "(glsl|glslify|vert|frag|\/\* ?glsl ?\*\/)(`)|(`)\/\/(inline|glsl)",
       "beginCaptures": {
         "1": {
           "patterns": [


### PR DESCRIPTION
This PR adds support for both `/* glsl */` and `/*glsl*/` prefixes.

Close #5 
